### PR TITLE
chore(status bar): status bar 제거

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -130,7 +130,7 @@ export default class LightboxOverlay extends Component {
 
   open = () => {
     if(isIOS) {
-      StatusBar.setHidden(true, 'fade');
+      // StatusBar.setHidden(true, 'fade');
     }
     this.state.pan.setValue(0);
     this.setState({
@@ -154,7 +154,7 @@ export default class LightboxOverlay extends Component {
   close = () => {
     this.props.willClose();
     if(isIOS) {
-      StatusBar.setHidden(false, 'fade');
+      // StatusBar.setHidden(false, 'fade');
     }
     this.setState({
       isAnimating: true,


### PR DESCRIPTION
RCTStatusBarManager module requires that the UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO
문제 때문에 
status bar 사용하는 부분 제거해야함